### PR TITLE
Fixed visual glitch with labels

### DIFF
--- a/client/src/components/Form.tsx
+++ b/client/src/components/Form.tsx
@@ -1,4 +1,4 @@
-import React, { createElement } from "react";
+import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 interface FormProps {
@@ -10,21 +10,11 @@ interface FormProps {
 export function Form({ defaultValues, children, onSubmit }: FormProps) {
   if (!children) return <></>;
   const methods = useForm({ defaultValues });
-  const { handleSubmit, register } = methods;
+  const { handleSubmit } = methods;
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <FormProvider {...methods}>
-        {React.Children.map(children, (child: JSX.Element) => {
-          if (child?.type?.name === "Input")
-            return createElement(child.type, {
-              register,
-              key: child.props.name,
-              ...child.props,
-            });
-          return child;
-        })}
-      </FormProvider>
+      <FormProvider {...methods}>{children}</FormProvider>
     </form>
   );
 }

--- a/client/src/components/Input.tsx
+++ b/client/src/components/Input.tsx
@@ -1,33 +1,21 @@
 import { ErrorMessage } from "@hookform/error-message";
-import { InputHTMLAttributes, useRef, useState } from "react";
-import {
-  FieldErrors,
-  RegisterOptions,
-  useFormContext,
-  UseFormRegister,
-} from "react-hook-form";
+import { InputHTMLAttributes, useEffect, useRef, useState } from "react";
+import { FieldErrors, RegisterOptions, useFormContext } from "react-hook-form";
 
 interface FancyInputProps extends InputHTMLAttributes<HTMLInputElement> {
   errors?: FieldErrors;
   name?: string;
-  register?: UseFormRegister<any> | Function;
   options?: RegisterOptions;
 }
 
-export default function Input({
-  name,
-  register,
-  options,
-  ...rest
-}: FancyInputProps) {
-  if (!register || !name) register = () => {};
-  else register = register(name, options || {});
-
-  const { formState } = useFormContext();
+export default function Input({ name, options, ...rest }: FancyInputProps) {
+  const { formState, register } = useFormContext();
   const { errors } = formState;
 
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
   const [labelSmall, setLabelSmall] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const { ref, ...regRest } = name ? register(name, options) : { ref: null };
 
   const handleFocus = (focus: boolean) =>
     inputRef.current?.value === "" ? setLabelSmall(focus) : setLabelSmall(true);
@@ -37,13 +25,17 @@ export default function Input({
       <div className="relative flex flex-col gap-2">
         <input
           {...rest}
-          ref={inputRef}
+          {...(ref ? regRest : {})}
+          ref={(e) => {
+            if (!ref) return inputRef;
+            ref(e);
+            inputRef.current = e;
+          }}
           onFocus={() => handleFocus(true)}
           onBlur={() => handleFocus(false)}
           className="rounded-md border border-gray-300 px-4 pt-4 pb-1"
           placeholder=""
           aria-placeholder={rest.placeholder || ""}
-          {...register}
         />
         <label
           className={`absolute select-none capitalize opacity-60 transition-all duration-300 ease-out ${


### PR DESCRIPTION
The Use Hook Form library was overwriting the ref I had set initially. After looking at the 
docs, I found a workaround to use the ref.

- Stopped using hooks in invalid places
- Fixed visual bug with labels